### PR TITLE
Update link to setup instructions

### DIFF
--- a/_includes/dc/setup.html
+++ b/_includes/dc/setup.html
@@ -55,7 +55,7 @@ Image workshops
 
 {% elsif site.curriculum == "dc-image" %}
 
-<p>The setup instructions for Data Carpentry Image Processing workshops can be found at <a href="https://datacarpentry.org/image-processing/setup/">the curriculum site</a></p>.
+<p>The setup instructions for Data Carpentry Image Processing workshops can be found at <a href="https://datacarpentry.org/image-processing/index.html#setup">the curriculum site</a></p>.
 
 {% comment %}
 Social sciences workshops


### PR DESCRIPTION
This should fix the link to the curriculum setup instructions