### PR TITLE
Use Ruby v3

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
 
       - name: Set up Python


### PR DESCRIPTION
This will fix the problem with the website builds, caused by a change to the versions of dependencies expected.